### PR TITLE
Add check for WSL and change NPM_REGISTRY accordingly

### DIFF
--- a/bin/lerna-docker
+++ b/bin/lerna-docker
@@ -41,10 +41,12 @@ sleep 1
 REGISTRY_PID=$!
 npm-cli-adduser --registry http://localhost:4873 --username lerna --password lerna --email lerna@example.org
 npx lerna exec -- npm publish --silent --registry http://localhost:4873 > /dev/null
-if [ "$(uname)" == "Darwin" ]; then
-    NPM_REGISTRY="http://host.docker.internal:4873/"
+
+# If we run on mac or WSL we use docker internal
+if [[ $(grep -i Microsoft /proc/version) ]] || ["$(uname)" == "Darwin"]; then
+        NPM_REGISTRY="http://host.docker.internal:4873/"
 else
-    NPM_REGISTRY="http://127.0.0.1:4873/"
+        NPM_REGISTRY="http://127.0.0.1:4873/"
 fi
 
 # Restart the temporary npm registry, but now add an uplink to npm


### PR DESCRIPTION
A new attempt at fixing lerna-docker for WSL, it only changes the NPM_REGISTRY to "http://host.docker.internal:4873/" if it detects WSL(1 or 2) and Mac.