### PR TITLE
Fix lerna docker wsl

### DIFF
--- a/bin/lerna-docker
+++ b/bin/lerna-docker
@@ -43,7 +43,7 @@ npm-cli-adduser --registry http://localhost:4873 --username lerna --password ler
 npx lerna exec -- npm publish --silent --registry http://localhost:4873 > /dev/null
 
 # If we run on Mac or WSL we use docker internal
-if [ -f "/proc/version" ] && [[ $(grep -i Microsoft /proc/version) ]] ||  [ "$(uname)" == "Darwin" ]; then
+if ([ -f "/proc/version" ] && [[ $(grep -i Microsoft /proc/version) ]]) ||  [ "$(uname)" == "Darwin" ]; then
     NPM_REGISTRY="http://host.docker.internal:4873/"
 else
     NPM_REGISTRY="http://127.0.0.1:4873/"

--- a/bin/lerna-docker
+++ b/bin/lerna-docker
@@ -42,8 +42,8 @@ REGISTRY_PID=$!
 npm-cli-adduser --registry http://localhost:4873 --username lerna --password lerna --email lerna@example.org
 npx lerna exec -- npm publish --silent --registry http://localhost:4873 > /dev/null
 
-# If we run on mac or WSL we use docker internal
-if [[ $(grep -i Microsoft /proc/version) ]] || ["$(uname)" == "Darwin"]; then
+# If we run on Mac or WSL we use docker internal
+if [ -f "/proc/version" ] && [[ $(grep -i Microsoft /proc/version) ]] ||  [ "$(uname)" == "Darwin" ]; then
     NPM_REGISTRY="http://host.docker.internal:4873/"
 else
     NPM_REGISTRY="http://127.0.0.1:4873/"

--- a/bin/lerna-docker
+++ b/bin/lerna-docker
@@ -41,10 +41,12 @@ sleep 1
 REGISTRY_PID=$!
 npm-cli-adduser --registry http://localhost:4873 --username lerna --password lerna --email lerna@example.org
 npx lerna exec -- npm publish --silent --registry http://localhost:4873 > /dev/null
-if [ "$(uname)" == "Darwin" ]; then
-    NPM_REGISTRY="http://host.docker.internal:4873/"
+
+# If we run on mac or WSL we use docker internal
+if [[ $(grep -i Microsoft /proc/version) ]] || ["$(uname)" == "Darwin"]; then
+        NPM_REGISTRY="http://host.docker.internal:4873/"
 else
-    NPM_REGISTRY="http://127.0.0.1:4873/"
+        NPM_REGISTRY="http://127.0.0.1:4873/"
 fi
 
 # Restart the temporary npm registry, but now add an uplink to npm

--- a/bin/lerna-docker
+++ b/bin/lerna-docker
@@ -44,9 +44,9 @@ npx lerna exec -- npm publish --silent --registry http://localhost:4873 > /dev/n
 
 # If we run on mac or WSL we use docker internal
 if [[ $(grep -i Microsoft /proc/version) ]] || ["$(uname)" == "Darwin"]; then
-        NPM_REGISTRY="http://host.docker.internal:4873/"
+    NPM_REGISTRY="http://host.docker.internal:4873/"
 else
-        NPM_REGISTRY="http://127.0.0.1:4873/"
+    NPM_REGISTRY="http://127.0.0.1:4873/"
 fi
 
 # Restart the temporary npm registry, but now add an uplink to npm


### PR DESCRIPTION
New fix for WSL, this time we explicitly check for WSL (1 or 2) before changing to "http://host.docker.internal:4873/". 